### PR TITLE
[Linux setup] Add link to fontconfig file

### DIFF
--- a/extras/fonts/README.md
+++ b/extras/fonts/README.md
@@ -16,7 +16,8 @@ Android Setup Help:
 
 Linux Setup Help:
   * Place the file in `~/.local/share/fonts/`
-  * Update fontconfig cache with `fc-cache -f`
+  * Create the following fontconfig file: [latest](https://github.com/maximbaz/dotfiles/blob/master/.config/fontconfig/conf.d/70-emojione-color.conf) ([snapshot](https://github.com/maximbaz/dotfiles/blob/b63b2fe4bb5362d207e407c646655070cd1251bc/.config/fontconfig/conf.d/70-emojione-color.conf))
+  * Update fontconfig cache with `$ fc-cache -f`
   * Chrome and all derivative apps (like Electron) will display color emoji after a restart.
   * Install a patched Cairo library to display color emoji in all GTK+ apps:
     * https://aur.archlinux.org/packages/cairo-coloredemoji


### PR DESCRIPTION
The font will actually not work on Linux in most apps until a correct fontconfig file is created. 

I'm still learning how to make it properly, but as of today I achieved some pretty good results (most apps can show most of emojis, but some of the newest emojis will not be rendered properly out of the box, unless an app makes actual effort to add the support). I believe it is worth sharing the current config with community.

I was in doubt whether to put a copy of my config in this repo or just link to it, in the end I decided to go with the latter. The main reason is that it will change as I learn how to improve it further, and I don't want to maintain the config in multiple places, just as I don't want community to miss out on the latest updates.

I added the link to the config in master branch (this link will always point to my latest config) and the link to the snapshot of my current config (this link will always work, even if I delete or rename the file in future).

Let me know if you are OK with merging this.