### PR TITLE
google font fix

### DIFF
--- a/extras/fonts/README.md
+++ b/extras/fonts/README.md
@@ -6,8 +6,9 @@ There's no better way to port our emoji into your device than through a native f
 https://github.com/Ranks/emojione/raw/master/extras/fonts/emojione-android.ttf
 
   * Compatible with rooted Android devices and Linux.
-  * Updated July 6, 2017
+  * Updated July 12, 2017
   * Developers using the font within their app, please review [this issue](https://github.com/Ranks/emojione/issues/385) regarding proper display of digits.
+  * Note that Chrome on all platforms currently doesn't support Emoji 5.0 so toned emojis in Emoji 5.0 will not be displayed properly. What supports Emoji 5.0: Firefox on all platforms (doesn't support subdivision flags on Linux), native Android TextView.
 
 Android Setup Help:
 * We recommend Emoji Switcher (now free for EmojiOne): https://play.google.com/store/apps/details?id=com.stevenschoen.emojiswitcher&hl=en


### PR DESCRIPTION
Due to a miss I made in the script (I didn't notice that the gender of `Mage(U+1F9D9)` is male but toned emojis of it are female), there are some problems with `Mage` and `Man Mage`. The new font fixes this.
Also added instructions to indicate where the new emojis in Emoji 5.0 works.