### PR TITLE
Add support for 24px and 40px sprite emoji

### DIFF
--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -258,7 +258,7 @@
                 fname = ns.emojioneList[shortname].uc_base;
                 category = (fname.includes("-1f3f")) ? 'diversity' : ns.emojioneList[shortname].category;
                 title = ns.imageTitleTag ? 'title="' + shortname + '"' : '';
-                size = (ns.spriteSize == '32' || ns.spriteSize == '64') ? ns.spriteSize : '32';
+                size = (ns.spriteSize == '24' || ns.spriteSize == '32' || ns.spriteSize == '40' || ns.spriteSize == '64') ? ns.spriteSize : '32';
                 //if the image path has not changed, we'll assume the default cdn path, otherwise we'll assume the provided path
                 ePath = (ns.imagePathPNG != ns.defaultPathPNG) ? ns.imagePathPNG : ns.defaultPathPNG + ns.emojiSize + '/';
 
@@ -292,7 +292,7 @@
                 shortname = mappedUnicode[unicode];
                 category = (unicode.includes("-1f3f")) ? 'diversity' : ns.emojioneList[shortname].category;
                 title = ns.imageTitleTag ? 'title="' + ns.escapeHTML(m3) + '"' : '';
-                size = (ns.spriteSize == '32' || ns.spriteSize == '64') ? ns.spriteSize : '32';
+                size = (ns.spriteSize == '24' || ns.spriteSize == '32' || ns.spriteSize == '40' || ns.spriteSize == '64') ? ns.spriteSize : '32';
                 //if the image path has not changed, we'll assume the default cdn path, otherwise we'll assume the provided path
                 ePath = (ns.imagePathPNG != ns.defaultPathPNG) ? ns.imagePathPNG : ns.defaultPathPNG + ns.emojiSize + '/';
 
@@ -343,7 +343,7 @@
             fname = eList[short].uc_base;
             unicode = eList[short].uc_output;
             category = (fname.includes("-1f3f")) ? 'diversity' : eList[short].category;
-            size = (ns.spriteSize == '32' || ns.spriteSize == '64') ? ns.spriteSize : '32';
+            size = (ns.spriteSize == '24' || ns.spriteSize == '32' || ns.spriteSize == '40' || ns.spriteSize == '64') ? ns.spriteSize : '32';
             //if the image path has not changed, we'll assume the default cdn path, otherwise we'll assume the provided path
             ePath = (ns.imagePathPNG != ns.defaultPathPNG) ? ns.imagePathPNG : ns.defaultPathPNG + ns.emojiSize + '/';
 
@@ -377,7 +377,7 @@
                 shortname = mappedUnicode[unicode];
                 category = (unicode.includes("-1f3f")) ? 'diversity' : ns.emojioneList[shortname].category;
                 title = ns.imageTitleTag ? 'title="' + ns.escapeHTML(m3) + '"' : '';
-                size = (ns.spriteSize == '32' || ns.spriteSize == '64') ? ns.spriteSize : '32';
+                size = (ns.spriteSize == '24' || ns.spriteSize == '32' || ns.spriteSize == '40' || ns.spriteSize == '64') ? ns.spriteSize : '32';
                 //if the image path has not changed, we'll assume the default cdn path, otherwise we'll assume the provided path
                 ePath = (ns.imagePathPNG != ns.defaultPathPNG) ? ns.imagePathPNG : ns.defaultPathPNG + ns.emojiSize + '/';
 


### PR DESCRIPTION
Setting the size to 24px or 40px currently doesn't work, however they are [valid sprite sizes](https://github.com/emojione/emojione-assets/tree/master/sprites)