### PR TITLE
Update setup instructions for Linux

### DIFF
--- a/extras/fonts/README.md
+++ b/extras/fonts/README.md
@@ -18,10 +18,10 @@ Android Setup Help:
 
 Linux Setup Help:
 
-* ArchLinux users are advised to install [AUR package](https://aur.archlinux.org/packages/emojione-fonts/)
+* ArchLinux users are advised to install [AUR package](https://aur.archlinux.org/packages/ttf-emojione/)
 * Alternatively setup the font manually:
   * Place the file in `~/.local/share/fonts/`
-  * Create the following fontconfig file: [snapshot](https://github.com/maximbaz/dotfiles/blob/b63b2fe4bb5362d207e407c646655070cd1251bc/.config/fontconfig/conf.d/70-emojione-color.conf)
+  * Create the following fontconfig file: [latest](https://aur.archlinux.org/cgit/aur.git/tree/70-emojione-color.conf?h=ttf-emojione) ([snapshot](https://github.com/maximbaz/dotfiles/blob/b63b2fe4bb5362d207e407c646655070cd1251bc/.config/fontconfig/conf.d/70-emojione-color.conf))
   * Update fontconfig cache with `$ fc-cache -f; sudo fc-cache -f`
 * The font seems to be working now in Chrome and Firefox, as well as in many other apps!
 

--- a/extras/fonts/README.md
+++ b/extras/fonts/README.md
@@ -21,7 +21,7 @@ Linux Setup Help:
 * ArchLinux users are advised to install [AUR package](https://aur.archlinux.org/packages/ttf-emojione/)
 * Alternatively setup the font manually:
   * Place the file in `~/.local/share/fonts/`
-  * Create the following fontconfig file: [latest](https://aur.archlinux.org/cgit/aur.git/tree/70-emojione-color.conf?h=ttf-emojione) ([snapshot](https://github.com/maximbaz/dotfiles/blob/b63b2fe4bb5362d207e407c646655070cd1251bc/.config/fontconfig/conf.d/70-emojione-color.conf))
+  * Create the following fontconfig file: [latest](https://aur.archlinux.org/cgit/aur.git/tree/70-emojione-color.conf?h=ttf-emojione) ([snapshot](https://github.com/maximbaz/dotfiles/blob/c893a835372c927eba9ec7e086e76b64f6210d8c/.config/fontconfig/conf.d/70-emojione-color.conf))
   * Update fontconfig cache with `$ fc-cache -f; sudo fc-cache -f`
 * The font seems to be working now in Chrome and Firefox, as well as in many other apps!
 

--- a/extras/fonts/README.md
+++ b/extras/fonts/README.md
@@ -17,13 +17,13 @@ Android Setup Help:
 * Must have a rooted Android phone.
 
 Linux Setup Help:
+
+* ArchLinux users are advised to install [AUR package](https://aur.archlinux.org/packages/emojione-fonts/)
+* Alternatively setup the font manually:
   * Place the file in `~/.local/share/fonts/`
-  * Create the following fontconfig file: [latest](https://github.com/maximbaz/dotfiles/blob/master/.config/fontconfig/conf.d/70-emojione-color.conf) ([snapshot](https://github.com/maximbaz/dotfiles/blob/b63b2fe4bb5362d207e407c646655070cd1251bc/.config/fontconfig/conf.d/70-emojione-color.conf))
-  * Update fontconfig cache with `$ fc-cache -f`
-  * Chrome and all derivative apps (like Electron) will display color emoji after a restart.
-  * Install a patched Cairo library to display color emoji in all GTK+ apps:
-    * https://aur.archlinux.org/packages/cairo-coloredemoji
-    * https://software.opensuse.org/package/libcairo2-color-emoji
+  * Create the following fontconfig file: [snapshot](https://github.com/maximbaz/dotfiles/blob/b63b2fe4bb5362d207e407c646655070cd1251bc/.config/fontconfig/conf.d/70-emojione-color.conf)
+  * Update fontconfig cache with `$ fc-cache -f; sudo fc-cache -f`
+* The font seems to be working now in Chrome and Firefox, as well as in many other apps!
 
 ### Apple Font
 


### PR DESCRIPTION
- AUR package is available for ArchLinux that takes care of the setup
- Patched cairo is no longer needed as the fix was finally merged in the upstream
- The font is working in Firefox now as well as in Chrome
- Update the link to fontconfig example (I switched to AUR package, so the first link is not available anymore)