### PR TITLE
Fix PHP asciiToShortnameCallback (called on ASCII to shortname conversion)

### DIFF
--- a/lib/php/src/Client.php
+++ b/lib/php/src/Client.php
@@ -342,7 +342,6 @@ class Client implements ClientInterface
             $ruleset = $this->getRuleset();
             $ascii_replace = $ruleset->getAsciiReplace();
 
-            $shortcode_replace = array_flip(array_reverse($ruleset->getShortcodeReplace()));
             $shortname = $m[3];
 
             if ( empty($ascii_replace[$shortname]) )
@@ -351,8 +350,7 @@ class Client implements ClientInterface
             }
             else
             {
-                $unicode = $ascii_replace[$shortname];
-                return $m[2].$shortcode_replace[$unicode];
+                return $m[2].$ascii_replace[$shortname];
             }
         }
     }


### PR DESCRIPTION
When converting ASCII smileys using asciiToShortname, asciiToShortnameCallback is called. This function executes array_flip(array_reverse($ruleset->getShortcodeReplace())); that always results in an empty array, replacing ASCII smileys with empty strings.
Also, function should return shortnames for smileys and not their unicode equivalents, therefore only $ascii_replace is needed.