### PR TITLE
 Add basic template support

### DIFF
--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -155,7 +155,7 @@
     ns.riskyMatchAscii = false; // set true to match ascii without leading/trailing space char
 
     ns.spriteTemplate = '<span class="emojione emojione-{{size}}-{{category}} _{{code}}" {{title}}>{{alt}}</span>';
-    ns.imageTemplate = '<img class="emojione" alt="{{alt}}" {{title}} src="{src}"/>';
+    ns.imageTemplate = '<img class="emojione" alt="{{alt}}" {{title}} src="{{src}}"/>';
     
     ns.regShortNames = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|("+ns.shortnames+")", "gi");
     ns.regAscii = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|((\\s|^)"+ns.asciiRegexp+"(?=\\s|$|[!,.?]))", "gi");

--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -154,6 +154,9 @@
     ns.ascii = false; // change to true to convert ascii smileys
     ns.riskyMatchAscii = false; // set true to match ascii without leading/trailing space char
 
+    ns.spriteTemplate = '<span class="emojione emojione-{{size}}-{{category}} _{{code}}" {{title}}>{{alt}}</span>';
+	ns.imageTemplate = '<img class="emojione" alt="{{alt}}" {{title}} src="{src}"/>';
+    
     ns.regShortNames = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|("+ns.shortnames+")", "gi");
     ns.regAscii = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|((\\s|^)"+ns.asciiRegexp+"(?=\\s|$|[!,.?]))", "gi");
     ns.regAsciiRisky = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|(()"+ns.asciiRegexp+"())", "gi");
@@ -270,12 +273,16 @@
                 // depending on the settings, we'll either add the native unicode as the alt tag, otherwise the shortname
                 alt = (ns.unicodeAlt) ? ns.convert(unicode.toUpperCase()) : shortname;
 
-                if(ns.sprites) {
-                    replaceWith = '<span class="emojione emojione-' + size + '-' + category + ' _' + fname + '" ' + title + '>' + alt + '</span>';
-                }
-                else {
-                    replaceWith = '<img class="emojione" alt="' + alt + '" ' + title + ' src="' + ePath + fname + ns.fileExtension + '"/>';
-                }
+                replaceWith = ns.sprites ? ns.spriteTemplate : ns.imageTemplate;
+
+                replaceWith = 
+                    replaceWith
+                    .replace('{{src}}', ePath + fname + ns.fileExtension)
+                    .replace('{{size}}', size)
+                    .replace('{{category}}', category)
+                    .replace('{{code}}', fname)
+                    .replace('{{title}}', title)
+                    .replace('{{alt}}', alt);
 
                 return replaceWith;
             }
@@ -304,12 +311,16 @@
                 // depending on the settings, we'll either add the native unicode as the alt tag, otherwise the shortname
                 alt = (ns.unicodeAlt) ? ns.convert(unicode.toUpperCase()) : ns.escapeHTML(m3);
 
-                if(ns.sprites) {
-                    replaceWith = m2+'<span class="emojione emojione-' + size + '-' + category + ' _' + unicode +'"  ' + title + '>' + alt + '</span>';
-                }
-                else {
-                    replaceWith = m2+'<img class="emojione" alt="'+alt+'" ' + title + ' src="' + ePath + unicode + ns.fileExtension + '"/>';
-                }
+                replaceWith = ns.sprites ? ns.spriteTemplate : ns.imageTemplate;
+
+                replaceWith = 
+                    m2 + replaceWith
+                    .replace('{{src}}', ePath + unicode + ns.fileExtension)
+                    .replace('{{size}}', size)
+                    .replace('{{category}}', category)
+                    .replace('{{code}}', unicode)
+                    .replace('{{title}}', title)
+                    .replace('{{alt}}', alt);
 
                 return replaceWith;
             });

--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -155,7 +155,7 @@
     ns.riskyMatchAscii = false; // set true to match ascii without leading/trailing space char
 
     ns.spriteTemplate = '<span class="emojione emojione-{{size}}-{{category}} _{{code}}" {{title}}>{{alt}}</span>';
-	ns.imageTemplate = '<img class="emojione" alt="{{alt}}" {{title}} src="{src}"/>';
+    ns.imageTemplate = '<img class="emojione" alt="{{alt}}" {{title}} src="{src}"/>';
     
     ns.regShortNames = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|("+ns.shortnames+")", "gi");
     ns.regAscii = new RegExp("<object[^>]*>.*?<\/object>|<span[^>]*>.*?<\/span>|<(?:object|embed|svg|img|div|span|p|a)[^>]*>|((\\s|^)"+ns.asciiRegexp+"(?=\\s|$|[!,.?]))", "gi");


### PR DESCRIPTION
This adds basic HTML template support for image and sprite elements by adding two new options to the global settings.

```
emojione.spriteTemplate = '<span class="emojione emojione-{{size}}-{{category}} _{{code}}" {{title}}>{{alt}}</span>';
emojione.imageTemplate = '<img class="emojione" alt="{{alt}}" {{title}} src="{{src}}"/>';
```

Current possible replacements are:
`{{src}}`
`{{size}}`
`{{category}}`
`{{code}}`
`{{title}}`
`{{alt}}`